### PR TITLE
Bugfixed call to method #to_params

### DIFF
--- a/lib/fetchapi/account.rb
+++ b/lib/fetchapi/account.rb
@@ -1,15 +1,15 @@
 module FetchAPI
   class Account < FetchAPI::Base
-	 attr_accessor :attributes
+   attr_accessor :attributes
     #--
     ################ Class Methods ###############
     #--
 
     # Retrieves information about the Account
     def self.details
-		account = Account.new({})
-		account.attributes = execute(:get, "/account")["account"]
-		account
+    account = Account.new({})
+    account.attributes = execute(:get, "/account")["account"]
+    account
     end
 
     # Generates a new API token.  Subsequent API calls using the
@@ -18,11 +18,9 @@ module FetchAPI
       token = execute(:get, "/new_token")
       unless token["message"].blank?
         # Reauthorize
-		  Connector.basic_auth(FetchAPI::Base.key, token["message"])
+        Connector.basic_auth(FetchAPI::Base.key, token["message"])
         token
       end
     end
-
   end
-
 end

--- a/lib/fetchapi/base.rb
+++ b/lib/fetchapi/base.rb
@@ -16,7 +16,7 @@ module FetchAPI
     def self.find(selector, params={}) #:nodoc:
       case selector
       when :all
-        objects = execute(:get, "/#{pluralized_class_name}#{"?" + params.to_params unless params.blank?}")
+        objects = execute(:get, "/#{pluralized_class_name}#{"?" + params.to_param unless params.blank?}")
 
         if objects[pluralized_class_name].blank?
           return []

--- a/lib/fetchapi/download.rb
+++ b/lib/fetchapi/download.rb
@@ -2,9 +2,9 @@ module FetchAPI
   class Download < FetchAPI::Base
     attr_accessor :id, :attributes
 
-	 # Find :all downloads or the specified ID
-	 def self.find(selector, params={})
-		   super(selector, params)
+   # Find :all downloads or the specified ID
+   def self.find(selector, params={})
+       super(selector, params)
     end
 
   end

--- a/lib/fetchapi/item.rb
+++ b/lib/fetchapi/item.rb
@@ -51,6 +51,5 @@ module FetchAPI
       end
     end
 
-
   end
 end

--- a/lib/fetchapi/order.rb
+++ b/lib/fetchapi/order.rb
@@ -6,14 +6,14 @@ module FetchAPI
     #--
     ################ Class Methods ###############
     #--
-    
-	 # Finds an Order or orders based on the specified parameters
-	 # :all, :current, :manual, :expired, or by ID
+
+   # Finds an Order or orders based on the specified parameters
+   # :all, :current, :manual, :expired, or by ID
     def self.find(selector, params={})
       case selector
       when :current
         params.merge!(:filter => "current")
-        orders = execute(:get, "/orders?#{params.to_params}")
+        orders = execute(:get, "/orders?#{params.to_param}")
         if orders["orders"].blank?
           return []
         else
@@ -21,7 +21,7 @@ module FetchAPI
         end
       when :manual
         params.merge!(:filter => "manual")
-        orders = execute(:get, "/orders?#{params.to_params}")
+        orders = execute(:get, "/orders?#{params.to_param}")
         if orders["orders"].blank?
           return []
         else
@@ -29,7 +29,7 @@ module FetchAPI
         end
       when :expired
         params.merge!(:filter => "expired")
-        orders = execute(:get, "/orders?#{params.to_params}")
+        orders = execute(:get, "/orders?#{params.to_param}")
         if orders["orders"].blank?
           return []
         else
@@ -71,8 +71,8 @@ module FetchAPI
     def update(options={})
       self.attributes = put("/orders/#{id}", :order => options)["order"]
     end
-    
-	 # Returns all the downloads associated with this Order
+
+   # Returns all the downloads associated with this Order
     def downloads(params={})
       downloads = get("/orders/#{id}/downloads")
       if downloads


### PR DESCRIPTION
That method does not exists. Maybe in older versions of ActiveSupport.
